### PR TITLE
Fixes constructing 'from' field

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function generate(tuples, options) {
   options = options || {};
   var boundary = options.boundary || uuid();
   var headers = [
-    'From: ' + options.from || ('nobody' + Date()),
+    'From: ' + (options.from || ('nobody ' + Date())),
     'MIME-Version: 1.0',
     'Content-Type:multipart/mixed; boundary=' + boundary
   ];


### PR DESCRIPTION
The order of operators was wrong: 'foo'+a||b is the same as ('foo'+a)||b

Also adds a whitespace between 'nobody' and the current date.
