### PR TITLE
Added a whitespace between header name and value

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function generate(tuples, options) {
   var headers = [
     'From: ' + (options.from || ('nobody ' + Date())),
     'MIME-Version: 1.0',
-    'Content-Type:multipart/mixed; boundary=' + boundary
+    'Content-Type: multipart/mixed; boundary=' + boundary
   ];
 
   var delimiter = '--' + boundary;

--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ test('produces valid mime multipart archive', function(t) {
 
   var content2 = { content: 'life' };
 
-  var expected = 'From: nobody Thu Apr 09 2015 14:24:54 GMT+0200\r\nMIME-Version: 1.0\r\nContent-Type:multipart/mixed; boundary=4987e8f2-34a1-41a5-a4aa-3bfc3398651d\r\n\r\n--4987e8f2-34a1-41a5-a4aa-3bfc3398651d\r\nMIME-Version: 1.0\r\nContent-Type: text/upstart-job; charset="ascii"\r\nContent-Transfer-Encoding: 7bit\r\nContent-Disposition: attachment; filename="file0"\r\n\r\nthug\r\n\r\n--4987e8f2-34a1-41a5-a4aa-3bfc3398651d\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset="utf8"\r\nContent-Transfer-Encoding: 7bit\r\nContent-Disposition: attachment; filename="file1"\r\n\r\nlife\r\n\r\n--4987e8f2-34a1-41a5-a4aa-3bfc3398651d--';
+  var expected = 'From: nobody Thu Apr 09 2015 14:24:54 GMT+0200\r\nMIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=4987e8f2-34a1-41a5-a4aa-3bfc3398651d\r\n\r\n--4987e8f2-34a1-41a5-a4aa-3bfc3398651d\r\nMIME-Version: 1.0\r\nContent-Type: text/upstart-job; charset="ascii"\r\nContent-Transfer-Encoding: 7bit\r\nContent-Disposition: attachment; filename="file0"\r\n\r\nthug\r\n\r\n--4987e8f2-34a1-41a5-a4aa-3bfc3398651d\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset="utf8"\r\nContent-Transfer-Encoding: 7bit\r\nContent-Disposition: attachment; filename="file1"\r\n\r\nlife\r\n\r\n--4987e8f2-34a1-41a5-a4aa-3bfc3398651d--';
 
   var result = multipart.generate([content1, content2], {
     boundary: '4987e8f2-34a1-41a5-a4aa-3bfc3398651d',


### PR DESCRIPTION
This is not a mistake according to RFC2616 (#4.2), but to be consistent it
makes sense to have single whitespace separating the value.
